### PR TITLE
Refactored repoLookup's input to its own component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules
 .idea
 dist
 .DS_Store
+npm-debug.log
 
 src/config/constants.js

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -20,3 +20,4 @@ body {
 @import '../../js/features/repoLookup/repoLookup.component';
 @import '../../js/features/repoLookup/userDisplay/userDisplay.component';
 @import '../../js/features/repoLookup/repoList/repoList.component';
+@import '../../js/features/repoLookup/usernameInput/usernameInput.component';

--- a/src/config/eslint/eslint.config.json
+++ b/src/config/eslint/eslint.config.json
@@ -66,7 +66,6 @@
     "no-floating-decimal": 2,
     "no-implicit-coercion": [2, {"boolean": true, "number": true, "string": true}],
     "no-implied-eval": 2,
-    "no-invalid-this": 2,
     "no-iterator": 2,
     "no-labels": 2,
     "no-lone-blocks": 2,

--- a/src/js/features/repoLookup/repoLookup.component.js
+++ b/src/js/features/repoLookup/repoLookup.component.js
@@ -1,32 +1,16 @@
-import repoLookupStore from './repoLookup.store';
-
 import UserDisplayComponent from './userDisplay/userDisplay.component';
 import RepoListComponent from './repoList/repoList.component';
+import UsernameInputComponent from './usernameInput/usernameInput.component';
 
 export default class RepoLookupComponent extends React.Component {
-    onSubmit(event) {
-        event.preventDefault();
-        const username = this.refs.username.value;
-        this.refs.username.value = '';
-        if (username) {
-            repoLookupStore.fetchData(username);
-        } else {
-            console.error('No Input!');
-        }
-    }
-
     render() {
         return (
             <div className="ns-repo-lookup">
                 <h1>Repo Lookup</h1>
-                <form onSubmit={event => this.onSubmit(event)}>
-                    <input ref="username" />
-                    <button type="submit">Find User</button>
-                </form>
+                <UsernameInputComponent />
                 <UserDisplayComponent />
                 <RepoListComponent />
             </div>
         );
     }
 }
-

--- a/src/js/features/repoLookup/repoLookup.component.scss
+++ b/src/js/features/repoLookup/repoLookup.component.scss
@@ -8,29 +8,4 @@
   h1 {
     color: $brand-primary;
   }
-
-  input {
-    padding: 3px;
-    width: 150px;
-    background: $brand-white;
-    border: none;
-    border-bottom: 2px $brand-primary solid;
-    border-radius: 5px;
-    color: $brand-black;
-    text-align: center;
-    margin-right: 20px;
-    outline-color: $brand-primary;
-    outline-offset: 3px;
-  }
-
-  button {
-    background: $brand-white;
-    border: none;
-    border-bottom: 2px $brand-primary solid;
-    border-radius: 5px;
-    color: $brand-black;
-    font-weight: bold;
-    outline-color: $brand-primary;
-    outline-offset: 3px;
-  }
 }

--- a/src/js/features/repoLookup/userDisplay/userDisplay.component.scss
+++ b/src/js/features/repoLookup/userDisplay/userDisplay.component.scss
@@ -2,7 +2,7 @@
   .content-container {
     width: 50%;
     min-width: 300px;
-    margin: 25px auto;
+    margin: 0 auto 25px;
     border-radius: 20px 0 20px 0;
     display: flex;
     justify-content: center;

--- a/src/js/features/repoLookup/usernameInput/usernameInput.component.js
+++ b/src/js/features/repoLookup/usernameInput/usernameInput.component.js
@@ -1,0 +1,31 @@
+import { action, observable } from 'mobx';
+import { observer } from 'mobx-react';
+import repoLookupStore from '../repoLookup.store';
+
+export default @observer class UsernameInputComponent extends React.Component {
+    @observable input = '';
+
+    @action onChange = event => {
+        this.input = event.target.value;
+    };
+
+    @action onSubmit = event => {
+        event.preventDefault();
+        const username = this.input;
+        if (username) {
+            repoLookupStore.fetchData(username);
+        } else {
+            console.error('No Input!');
+        }
+        this.input = '';
+    };
+
+    render() {
+        return (
+            <form onSubmit={this.onSubmit} className="ns-username-input-container">
+                <input onChange={this.onChange} value={this.input} />
+                <button type="submit">Find User</button>
+            </form>
+        );
+    }
+}

--- a/src/js/features/repoLookup/usernameInput/usernameInput.component.scss
+++ b/src/js/features/repoLookup/usernameInput/usernameInput.component.scss
@@ -1,0 +1,26 @@
+.ns-username-input-container {
+  input {
+    padding: 3px;
+    width: 150px;
+    background: $brand-white;
+    border: none;
+    border-bottom: 2px $brand-primary solid;
+    border-radius: 5px;
+    color: $brand-black;
+    text-align: center;
+    margin-right: 20px;
+    outline-color: $brand-primary;
+    outline-offset: 3px;
+  }
+
+  button {
+    background: $brand-white;
+    border: none;
+    border-bottom: 2px $brand-primary solid;
+    border-radius: 5px;
+    color: $brand-black;
+    font-weight: bold;
+    outline-color: $brand-primary;
+    outline-offset: 3px;
+  }
+}


### PR DESCRIPTION
### Change Summary
- Refactored repoLookup's input to be its own component
- Nixed the `no-invalid-this` eslint rule because it was erroring out on using arrow functions to automate lexical `this` binding.
- Added `npm-debug.log` to `.gitignore`
#### Notes:
- The new usernameInput component uses MobX to maintain state, but doesn't use an explicit store. This is the approach that I touched upon with @pabloalonsos earlier today.
