### PR TITLE
Updated observer comps to use mobx-provide & export a vanilla comp

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "html-webpack-plugin": "2.22.0",
     "lodash": "4.14.1",
     "mobx": "2.4.1",
+    "mobx-provide": "1.0.3",
     "mobx-react": "3.5.3",
     "mobx-react-devtools": "4.2.4",
     "node-sass": "3.8.0",

--- a/src/js/features/repoLookup/repoList/repoList.component.js
+++ b/src/js/features/repoLookup/repoList/repoList.component.js
@@ -1,9 +1,14 @@
 import { observer } from 'mobx-react';
+import provide from 'mobx-provide';
 import repoLookupStore from '../repoLookup.store';
 
-export default @observer class RepoListComponent extends React.Component {
+export class RepoListComponent extends React.Component {
+    static propTypes = {
+        repoLookupStore: React.PropTypes.object.isRequired
+    };
+
     render() {
-        const { repoData } = repoLookupStore;
+        const { repoData } = this.props.repoLookupStore;
         return (
             <div className="ns-repo-list-container">
                 <ul>
@@ -21,3 +26,7 @@ export default @observer class RepoListComponent extends React.Component {
         );
     }
 }
+
+const ObserverComponent = observer(RepoListComponent);
+
+export default provide({ repoLookupStore })(ObserverComponent);

--- a/src/js/features/repoLookup/userDisplay/userDisplay.component.js
+++ b/src/js/features/repoLookup/userDisplay/userDisplay.component.js
@@ -1,9 +1,14 @@
 import { observer } from 'mobx-react';
+import provide from 'mobx-provide';
 import repoLookupStore from '../repoLookup.store';
 
-export default @observer class UserDisplayComponent extends React.Component {
+export class UserDisplayComponent extends React.Component {
+    static propTypes = {
+        repoLookupStore: React.PropTypes.object.isRequired
+    };
+
     render() {
-        const { userData } = repoLookupStore;
+        const { userData } = this.props.repoLookupStore;
         return (
             <div className="ns-user-display-container">
                 {userData ?
@@ -21,3 +26,7 @@ export default @observer class UserDisplayComponent extends React.Component {
         );
     }
 }
+
+const ObserverComponent = observer(UserDisplayComponent);
+
+export default provide({ repoLookupStore })(ObserverComponent);

--- a/src/js/features/repoLookup/usernameInput/usernameInput.component.js
+++ b/src/js/features/repoLookup/usernameInput/usernameInput.component.js
@@ -1,8 +1,13 @@
 import { action, observable } from 'mobx';
 import { observer } from 'mobx-react';
+import provide from 'mobx-provide';
 import repoLookupStore from '../repoLookup.store';
 
-export default @observer class UsernameInputComponent extends React.Component {
+export class UsernameInputComponent extends React.Component {
+    static propTypes = {
+        repoLookupStore: React.PropTypes.object.isRequired
+    };
+
     @observable input = '';
 
     @action onChange = event => {
@@ -11,12 +16,15 @@ export default @observer class UsernameInputComponent extends React.Component {
 
     @action onSubmit = event => {
         event.preventDefault();
+
         const username = this.input;
+
         if (username) {
-            repoLookupStore.fetchData(username);
+            this.props.repoLookupStore.fetchData(username);
         } else {
             console.error('No Input!');
         }
+
         this.input = '';
     };
 
@@ -29,3 +37,7 @@ export default @observer class UsernameInputComponent extends React.Component {
         );
     }
 }
+
+const ObserverComponent = observer(UsernameInputComponent);
+
+export default provide({ repoLookupStore })(ObserverComponent);


### PR DESCRIPTION
### Change Summary
- Rearranged all `@observer` components to follow a new pattern:
  - create (and export) the vanilla React class
  - declare an ObserverComponent, which wraps the vanilla class in `@observer`
  - export default `provide({ store})(ObserverComponent)` for the fully functional component
#### Notes:
- The downside to this approach is that semantics get a little loosey-goosey. Please let me know if any object destructuring assignments or other in-component references to the store don't make intuitive sense.
